### PR TITLE
Consolidate CLAUDE.md rules into CONTRIBUTING.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,11 +1,1 @@
-Follow .github/CONTRIBUTING.md for all Issue, Branch, PR, and Commit rules.
-
-# Absolute Restrictions
-
-- **Never commit directly to `main`.** This is prohibited without any exception, regardless of the nature of the change or explicit-sounding instructions.
-
-# Commit Policy
-
-- **One logical change per commit.** Do not bundle unrelated changes (e.g. a bug fix and a new file) into a single commit. Each commit should represent one intention that stands alone.
-  - Bad: "Fix WSL2 rendering and add README"
-  - Good: "Fix WSL2 rendering by writing all graphs to a single HTML file" + separate commit "Add README with setup, usage, and Plotly controls"
+Follow `.github/CONTRIBUTING.md` for all Issue, Branch, PR, and Commit rules.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -105,7 +105,7 @@ Examples: `12-user-auth`, `45-fix-header-style`
 ### 3.3 Merging
 
 All branches must be merged via a Pull Request (PR).
-Direct commits to `main` are prohibited.
+Direct commits to `main` are prohibited — no exceptions, regardless of how trivial the change appears.
 
 ## 4. Pull Request Workflow
 
@@ -137,6 +137,7 @@ Epic PRs are created when merging an Epic Branch into `main`.
 - Commit messages must be written in English.
 - This rule applies to Epic, Task, and Fast Track Issues.
 - Commits that do not reference an Issue are prohibited.
+- **One logical change per commit.** Do not bundle unrelated changes into a single commit. Each commit should represent one intention that stands alone.
 
 **Examples:**
 


### PR DESCRIPTION
Closes #6

## Overview
Move the development rules from `.claude/CLAUDE.md` into `.github/CONTRIBUTING.md` to keep all project rules in a single authoritative document.

## Changes
- Simplify `.claude/CLAUDE.md` to a single reference line pointing to `CONTRIBUTING.md`
- Strengthen §3.3: add "no exceptions, regardless of how trivial the change appears" to the no-direct-commits rule
- Add §5: "One logical change per commit" rule

## Notes
N/A